### PR TITLE
RAM consumption fix and the quality of life changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -128,3 +128,7 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+
+TransPath_data
+wandb

--- a/data/hmaps.py
+++ b/data/hmaps.py
@@ -110,30 +110,25 @@ class GridData(Dataset):
     def __init__(self, path, mode='f', clip_value=0.95):
         self.clip_v = clip_value
         self.mode = mode
-        maps = np.load(os.path.join(path, 'maps.npy'), mmap_mode='c')
-        self.maps = maps
-        goals = np.load(os.path.join(path, 'goals.npy'), mmap_mode='c')
-        self.goals = goals
-        starts = np.load(os.path.join(path, 'starts.npy'), mmap_mode='c')
-        self.starts = starts
+
+        self.maps   = np.load(os.path.join(path,    'maps.npy'),    mmap_mode='c')
+        self.goals  = np.load(os.path.join(path,    'goals.npy'),   mmap_mode='c')
+        self.starts = np.load(os.path.join(path,    'starts.npy'),  mmap_mode='c')
         
-        if mode == 'f':
-            gt_values = np.load(os.path.join(path, 'focal.npy'), mmap_mode='c')
-            gt_values = gt_values
-            self.gt_values = gt_values
-            # self.gt_values = torch.where(gt_values >= clip_value, gt_values, torch.zeros_like(gt_values))
-        elif mode == 'h':
-            gt_values = np.load(os.path.join(path, 'abs.npy'), mmap_mode='c')
-            self.gt_values = gt_values
-        elif mode == 'cf':
-            gt_values = np.load(os.path.join(path, 'cf.npy'), mmap_mode='c')
-            self.gt_values = gt_values
-    
+        file_gt = {'f' : 'focal.npy', 'h':'abs.npy', 'cf': 'cf.npy'}[mode]
+        self.gt_values = np.load(os.path.join(path, file_gt), mmap_mode='c')
+
+
     def __len__(self):
         return len(self.gt_values)
+    
+    
     
     def __getitem__(self, idx):
         gt_ = torch.from_numpy(self.gt_values[idx].astype('float32'))
         if self.mode == 'f':
             gt_=  torch.where( gt_ >= self.clip_v, gt_ , torch.zeros_like( torch.from_numpy(self.gt_values[idx])))
-        return torch.from_numpy(self.maps[idx].astype('float32')), torch.from_numpy(self.starts[idx].astype('float32')), torch.from_numpy(self.goals[idx].astype('float32')), gt_
+        return (torch.from_numpy(self.maps[idx].astype('float32')), 
+                torch.from_numpy(self.starts[idx].astype('float32')), 
+                torch.from_numpy(self.goals[idx].astype('float32')), 
+                gt_ )

--- a/train.py
+++ b/train.py
@@ -5,11 +5,13 @@ import pytorch_lightning as pl
 import wandb
 from torch.utils.data import DataLoader
 from pytorch_lightning.loggers import WandbLogger
+import torch
 
 import argparse
+import multiprocessing
 
 
-def main(mode, run_name, proj_name):
+def main(mode, run_name, proj_name, batch_size, max_epochs):
     train_data = GridData(
         path='./TransPath_data/train',
         mode=mode
@@ -18,19 +20,25 @@ def main(mode, run_name, proj_name):
         path='./TransPath_data/val',
         mode=mode
     )
-    print('loading finished')
-    train_dataloader = DataLoader(train_data, batch_size=64,
-                        shuffle=True, num_workers=0, pin_memory=True)
-    val_dataloader = DataLoader(val_data, batch_size=64,
-                        shuffle=False, num_workers=0, pin_memory=True)
+    train_dataloader = DataLoader(  train_data, 
+                                    batch_size=batch_size,
+                                    shuffle=True, 
+                                    num_workers=multiprocessing.cpu_count(), 
+                                    pin_memory=True)
+    val_dataloader = DataLoader(    val_data, 
+                                    batch_size=batch_size,
+                                    shuffle=False, 
+                                    num_workers=multiprocessing.cpu_count(), 
+                                    pin_memory=True)
+    
     samples = next(iter(val_dataloader))
     
     model = Autoencoder(mode=mode)
-    wandb_logger = WandbLogger(project=proj_name, name=run_name)
+    wandb_logger = WandbLogger(project=proj_name, name=f'{run_name}_{mode}')
     trainer = pl.Trainer(
         logger=wandb_logger,
         accelerator="auto",
-        max_epochs=50,
+        max_epochs=max_epochs,
         deterministic=False,
         callbacks=[PathLogger(samples, mode=mode)],
     )
@@ -43,12 +51,16 @@ if __name__ == '__main__':
     parser.add_argument('--run_name', type=str, default='default')
     parser.add_argument('--proj_name', type=str, default='TransPath_runs')
     parser.add_argument('--seed', type=int, default=39)
+    parser.add_argument('--batch', type=int, default=256)
+    parser.add_argument('--epoch', type=int, default=15)
     
     args = parser.parse_args()
     pl.seed_everything(args.seed)
-    
+    torch.set_float32_matmul_precision('high') #fix for tesor blocks warning with new video card
     main(
         mode=args.mode,
         run_name=args.run_name,
-        proj_name=args.proj_name
+        proj_name=args.proj_name,
+        batch_size=args.batch,
+        max_epochs=args.epoch
     )

--- a/train.py
+++ b/train.py
@@ -18,9 +18,10 @@ def main(mode, run_name, proj_name):
         path='./TransPath_data/val',
         mode=mode
     )
-    train_dataloader = DataLoader(train_data, batch_size=256,
+    print('loading finished')
+    train_dataloader = DataLoader(train_data, batch_size=64,
                         shuffle=True, num_workers=0, pin_memory=True)
-    val_dataloader = DataLoader(val_data, batch_size=256,
+    val_dataloader = DataLoader(val_data, batch_size=64,
                         shuffle=False, num_workers=0, pin_memory=True)
     samples = next(iter(val_dataloader))
     
@@ -28,7 +29,7 @@ def main(mode, run_name, proj_name):
     wandb_logger = WandbLogger(project=proj_name, name=run_name)
     trainer = pl.Trainer(
         logger=wandb_logger,
-        gpus=-1,
+        accelerator="auto",
         max_epochs=50,
         deterministic=False,
         callbacks=[PathLogger(samples, mode=mode)],


### PR DESCRIPTION
### RAM consumption

In the original repo all dataset was loaded in RAM, so it crashes on pc with ram+swap lower than 40 GB. 

This commit loads and cast to tensor only when `__getitem___` was called.

### Quality of life changes

1. Expand CLI interface: batch size and epoch amount
2. `.gitignore`: wandb files and dataset
3. fix warning that triggers by `DataLoader` when `num_workers` is set to 0
4. fix warning that triggers by `torch` on new videocard with tensor cores (RTX4070ti)

### last version `pytorch_lightning.Trainer` fix

API was changed, and it needs argument `accelerator` instead `gpus`